### PR TITLE
surface: add support for odd resolutions

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -22,6 +22,10 @@ pub struct Image<'a> {
     /// Whether the image was derived using the `vaDeriveImage` API or created using the
     /// `vaCreateImage` API.
     derived: bool,
+    /// The display resolution requested by the client. The implementation is
+    /// free to enlarge this value as needed. In any case, we guarantee that an
+    /// image at least as large is returned.
+    display_resolution: (u32, u32),
 }
 
 impl<'a> Image<'a> {
@@ -32,6 +36,7 @@ impl<'a> Image<'a> {
         picture: &'a Picture<PictureSync>,
         image: bindings::VAImage,
         derived: bool,
+        display_resolution: (u32, u32),
     ) -> Result<Self, VaError> {
         let mut addr = std::ptr::null_mut();
 
@@ -41,6 +46,11 @@ impl<'a> Image<'a> {
             bindings::vaMapBuffer(picture.display().handle(), image.buf, &mut addr)
         }) {
             Ok(_) => {
+                // Assert that libva provided us with a coded resolution that is
+                // at least as large as `display_resolution`.
+                assert!(u32::from(image.width) >= display_resolution.0);
+                assert!(u32::from(image.height) >= display_resolution.1);
+
                 // Safe since `addr` points to data mapped onto our address space since we called
                 // `vaMapBuffer` above, which also guarantees that the data is valid for
                 // `image.data_size`.
@@ -51,6 +61,7 @@ impl<'a> Image<'a> {
                     image,
                     data,
                     derived,
+                    display_resolution,
                 })
             }
             Err(e) => {
@@ -74,6 +85,18 @@ impl<'a> Image<'a> {
     /// being a view/copy of said `Picture` in a guaranteed pixel format.
     pub fn is_derived(&self) -> bool {
         self.derived
+    }
+
+    /// Returns the display resolution as passed in by the client. This is a
+    /// value that is less than or equal to the coded resolution.
+    pub fn display_resolution(&self) -> (u32, u32) {
+        self.display_resolution
+    }
+
+    /// Returns the coded resolution. This value can be larger than the value
+    /// passed in when the image was created if the driver needs to.
+    pub fn coded_resolution(&self) -> (u32, u32) {
+        (self.image.width.into(), self.image.height.into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,10 @@ mod tests {
             .find(|f| f.fourcc == bindings::constants::VA_FOURCC_NV12)
             .expect("No valid VAImageFormat found for NV12");
 
-        let image = picture.create_image(image_fmt, width, height).unwrap();
+        let resolution = (width, height);
+        let image = picture
+            .create_image(image_fmt, resolution, resolution)
+            .unwrap();
 
         assert_eq!(crc_nv12_image(&image), 0xa5713e52);
     }


### PR DESCRIPTION
Add support for odd resolutions by remembering the display and coded resolutions.

Clients can use the display resolution to download data from the surface, while the coded resolution remains used for surface creation and for the underlying allocation.