### PR TITLE
buffer: av1: add support for slice parameter arrays

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -39,6 +39,15 @@ impl Buffer {
     pub(crate) fn new(context: Rc<Context>, mut type_: BufferType) -> Result<Self, VaError> {
         let mut buffer_id = 0;
 
+        /* we send all slices parameters as a single array in AV1 */
+        let nb_elements = match type_ {
+            BufferType::SliceParameter(ref mut slice_param) => match slice_param {
+                SliceParameter::AV1(params) => params.inner_mut().len(),
+                _ => 1,
+            },
+            _ => 1,
+        };
+
         let (ptr, size) = match type_ {
             BufferType::PictureParameter(ref mut picture_param) => match picture_param {
                 PictureParameter::MPEG2(ref mut wrapper) => (
@@ -101,8 +110,8 @@ impl Buffer {
                     std::mem::size_of_val(wrapper.inner_mut()),
                 ),
                 SliceParameter::AV1(ref mut wrapper) => (
-                    wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
-                    std::mem::size_of_val(wrapper.inner_mut()),
+                    wrapper.inner_mut().as_mut_ptr() as *mut std::ffi::c_void,
+                    std::mem::size_of::<bindings::VASliceParameterBufferAV1>(),
                 ),
             },
 
@@ -202,7 +211,7 @@ impl Buffer {
                 context.id(),
                 type_.inner(),
                 size as u32,
-                1,
+                nb_elements as u32,
                 ptr,
                 &mut buffer_id,
             )

--- a/src/buffer/av1.rs
+++ b/src/buffer/av1.rs
@@ -516,13 +516,21 @@ impl PictureParameterBufferAV1 {
     }
 }
 
-/// A wrapper over `VASliceParameterBufferAV1` FFI type
-pub struct SliceParameterBufferAV1(Box<bindings::VASliceParameterBufferAV1>);
+/// A wrapper over an array of the `VASliceParameterBufferAV1` FFI type. This
+/// allows for passing all tile parameters in a single call if multiple tiles
+/// are present in the tile group.
+pub struct SliceParameterBufferAV1(Vec<bindings::VASliceParameterBufferAV1>);
 
 impl SliceParameterBufferAV1 {
     /// Creates the wrapper
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+
+    /// Adds a slice parameter to the wrapper
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn add_slice_parameter(
+        &mut self,
         slice_data_size: u32,
         slice_data_offset: u32,
         slice_data_flag: u32,
@@ -532,8 +540,8 @@ impl SliceParameterBufferAV1 {
         tg_end: u16,
         anchor_frame_idx: u8,
         tile_idx_in_tile_list: u16,
-    ) -> Self {
-        Self(Box::new(bindings::VASliceParameterBufferAV1 {
+    ) {
+        self.0.push(bindings::VASliceParameterBufferAV1 {
             slice_data_size,
             slice_data_offset,
             slice_data_flag,
@@ -544,10 +552,10 @@ impl SliceParameterBufferAV1 {
             anchor_frame_idx,
             tile_idx_in_tile_list,
             va_reserved: Default::default(),
-        }))
+        });
     }
 
-    pub(crate) fn inner_mut(&mut self) -> &mut bindings::VASliceParameterBufferAV1 {
+    pub(crate) fn inner_mut(&mut self) -> &mut Vec<bindings::VASliceParameterBufferAV1> {
         self.0.as_mut()
     }
 }


### PR DESCRIPTION
The intel driver expects the parameters for all tiles in a tile group to be submitted together as a single slice parameter array. This was previously unsupported, so fix it.