### PR TITLE
Correct name of soong license build config

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 license {
-    name: "external_rust_crates_cros-libva_license",
+    name: "external_rust_cros-libva_license",
     visibility: [":__subpackages__"],
     license_kinds: ["SPDX-license-identifier-BSD-3-Clause"],
     license_text: ["LICENSE"],

--- a/android/Android.bp
+++ b/android/Android.bp
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 package {
-    default_applicable_licenses: ["external_rust_crates_cros-libva_license"],
+    default_applicable_licenses: ["external_rust_cros-libva_license"],
 }
 
 rust_binary_host {

--- a/lib/Android.bp
+++ b/lib/Android.bp
@@ -6,7 +6,7 @@
 // Do not modify this file because the changes will be overridden on upgrade.
 
 package {
-    default_applicable_licenses: ["external_rust_crates_cros-libva_license"],
+    default_applicable_licenses: ["external_rust_cros-libva_license"],
 }
 
 rust_test {


### PR DESCRIPTION
cros-libva is located at platform/external/rust/cros-libva in AOSP. This corrects the name used in soong license build config.