### PR TITLE
Enable to generate intel protected content headers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,11 @@ jobs:
         make && \
         make install
     - name: Build
-      run: cargo build --all-features --verbose --workspace --tests --examples
+      # Not --all-features because a header for --intel-protected-content-headers is not usually available.
+      run: cargo build --verbose --workspace --tests --examples
     - name: Clippy
-      run: cargo clippy --all-features --workspace --tests --examples
+      # Not --all-features because a header for --intel-protected-content-headers is not usually available.
+      run: cargo clippy --workspace --tests --examples
     - name: Run tests
       run: cargo test --verbose
     - name: Format

--- a/android/Android.bp
+++ b/android/Android.bp
@@ -6,6 +6,25 @@ package {
     default_applicable_licenses: ["external_rust_cros-libva_license"],
 }
 
+soong_config_module_type_import {
+    from: "system/cros-codecs/Android.bp",
+    module_types: [
+        "rust_defaults_cros_codecs_protected_content",
+    ],
+}
+
+rust_defaults_cros_codecs_protected_content {
+    name: "cros_libva_protected_content_rust_bindgen_defaults",
+    soong_config_variables: {
+        intel_protected_content: {
+            header_libs: [
+                "//vendor/intel/widevine/oemcrypto:liboemcrypto_intel_headers",
+            ],
+            cflags: ["-DINTEL_PROTECTED_CONTENT_HEADERS"],
+        },
+    },
+}
+
 rust_binary_host {
     name: "cros_libva_bindgen_build",
     srcs: ["build.rs"],
@@ -31,8 +50,9 @@ rust_bindgen {
     custom_bindgen: "cros_libva_bindgen_build",
     wrapper_src: "android_wrapper.h",
     source_stem: "bindings",
-    cflags: ["-I external/rust/crates/cros-libva/lib"],
-    visibility: ["//external/rust/crates/cros-libva/lib"],
+    cflags: ["-I external/rust/cros-libva/lib"],
+    visibility: ["//external/rust/cros-libva/lib"],
+    defaults: ["cros_libva_protected_content_rust_bindgen_defaults"],
 
     vendor: true,
     enabled: false,

--- a/lib/Android.bp
+++ b/lib/Android.bp
@@ -9,6 +9,22 @@ package {
     default_applicable_licenses: ["external_rust_cros-libva_license"],
 }
 
+soong_config_module_type_import {
+    from: "system/cros-codecs/Android.bp",
+    module_types: [
+        "rust_defaults_cros_codecs_protected_content",
+    ],
+}
+
+rust_defaults_cros_codecs_protected_content {
+    name: "cros_libva_protected_content_rust_library_defaults",
+    soong_config_variables: {
+        intel_protected_content: {
+            features: ["intel-protected-content-headers"],
+        },
+    },
+}
+
 rust_library {
     name: "libcros_libva",
     crate_name: "cros_libva",
@@ -16,6 +32,7 @@ rust_library {
     cargo_pkg_version: "0.0.8",
     crate_root: "src/lib.rs",
     edition: "2021",
+    defaults: ["cros_libva_protected_content_rust_library_defaults"],
     rustlibs: [
         "libbitflags",
         "liblog_rust",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 
 readme.workspace = true
 
+[features]
+intel-protected-content-headers = []
+
 [dependencies]
 thiserror = "1"
 bitflags = "2.5"

--- a/lib/bindgen_gen.rs
+++ b/lib/bindgen_gen.rs
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// The allow list of VA functions, structures and enum values.
-const ALLOW_LIST_TYPE : &str = ".*ExternalBuffers.*|.*PRIME.*|.*MPEG2.*|.*VP8.*|.*VP9.*|.*H264.*|.*HEVC.*|.*JPEG.*|VACodedBufferSegment|.*AV1.*|VAEncMisc.*|VASurfaceDecodeMBErrors|VADecodeErrorType|.*VAProc.*";
+/// The allow list of VA structures and enum values.
+const ALLOW_LIST_TYPE: &str =
+    ".*ExternalBuffers.*|.*PRIME.*|.*MPEG2.*|.*VP8.*|.*VP9.*|.*H264.*|.*HEVC.*|\
+    .*JPEG.*|VACodedBufferSegment|.*AV1.*|VAEncMisc.*|VASurfaceDecodeMBErrors|\
+    VADecodeErrorType|.*VAProc.*|\
+    VACenc.*|VA_TEE_.*|VAEncryption.*|VA_PROTECTED_.*";
 
 // The common bindgen builder for VA-API.
 pub fn vaapi_gen_builder(builder: bindgen::Builder) -> bindgen::Builder {

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -15,6 +15,7 @@ use bindgen_gen::vaapi_gen_builder;
 /// files to use to generate the bindings.
 const CROS_LIBVA_H_PATH_ENV: &str = "CROS_LIBVA_H_PATH";
 const CROS_LIBVA_LIB_PATH_ENV: &str = "CROS_LIBVA_LIB_PATH";
+const CROS_LIBVA_PROTECTED_CONTENT_H_PATH_ENV: &str = "CROS_LIBVA_PROTECTED_CONTENT_H_PATH";
 
 /// Wrapper file to use as input of bindgen.
 const WRAPPER_PATH: &str = "libva-wrapper.h";
@@ -129,6 +130,17 @@ fn main() {
     if !va_h_path.is_empty() {
         bindings_builder = bindings_builder.clang_arg(format!("-I{}", va_h_path));
     }
+
+    if std::env::var("CARGO_FEATURE_INTEL_PROTECTED_CONTENT_HEADERS").is_ok() {
+        println!("cargo:warning=Building with intel protected content headers!");
+        bindings_builder = bindings_builder.clang_arg("-DINTEL_PROTECTED_CONTENT_HEADERS");
+        let va_p_h_path_env = env::var(CROS_LIBVA_PROTECTED_CONTENT_H_PATH_ENV);
+        if va_p_h_path_env.is_ok() {
+            let va_p_h_path = va_p_h_path_env.unwrap();
+            bindings_builder = bindings_builder.clang_arg(format!("-I{}", va_p_h_path));
+        }
+    }
+
     let bindings = bindings_builder
         .generate()
         .expect("unable to generate bindings");

--- a/lib/libva-wrapper.h
+++ b/lib/libva-wrapper.h
@@ -5,3 +5,7 @@
 #include <va/va.h>
 #include <va/va_drm.h>
 #include <va/va_drmcommon.h>
+
+#if defined(INTEL_PROTECTED_CONTENT_HEADERS)
+#include <va_protected_content.h>
+#endif  // defined(INTEL_PROTECTED_CONTENT_HEADERS)


### PR DESCRIPTION
Adds the feature to generate intel protected content headers. The path is optionally specified with
`CROS_LIBVA_PROTECTED_CONTENT_H_PATH`. Android.bp is modified for Android code structure and build system.