### PR TITLE
Add version checks down to VAAPI 1.10

### DIFF
--- a/lib/build.rs
+++ b/lib/build.rs
@@ -100,6 +100,15 @@ fn main() {
         major > desired_major || (major == desired_major && minor >= desired_minor)
     };
 
+    // Declare the custom cfg flags to avoid warnings
+    println!("cargo::rustc-check-cfg=cfg(libva_1_21_or_higher)");
+    println!("cargo::rustc-check-cfg=cfg(libva_1_20_or_higher)");
+    println!("cargo::rustc-check-cfg=cfg(libva_1_19_or_higher)");
+    println!("cargo::rustc-check-cfg=cfg(libva_1_16_or_higher)");
+    println!("cargo::rustc-check-cfg=cfg(libva_1_14_or_higher)");
+    println!("cargo::rustc-check-cfg=cfg(libva_1_10_or_higher)");
+
+    // Set the cfg flags based on version
     if va_check_version(1, 21) {
         println!("cargo::rustc-cfg=libva_1_21_or_higher");
     }
@@ -111,6 +120,12 @@ fn main() {
     }
     if va_check_version(1, 16) {
         println!("cargo::rustc-cfg=libva_1_16_or_higher")
+    }
+    if va_check_version(1, 14) {
+        println!("cargo::rustc-cfg=libva_1_14_or_higher");
+    }
+    if va_check_version(1, 10) {
+        println!("cargo::rustc-cfg=libva_1_10_or_higher");
     }
 
     if !va_lib_path.is_empty() {

--- a/lib/src/buffer.rs
+++ b/lib/src/buffer.rs
@@ -4,6 +4,7 @@
 
 //! Wrappers and helpers around `VABuffer`s.
 
+#[cfg(libva_1_14_or_higher)]
 mod av1;
 mod enc_jpeg;
 mod enc_misc;
@@ -15,6 +16,7 @@ mod proc_pipeline;
 mod vp8;
 mod vp9;
 
+#[cfg(libva_1_14_or_higher)]
 pub use av1::*;
 pub use enc_jpeg::*;
 pub use enc_misc::*;
@@ -52,6 +54,7 @@ impl Buffer {
             BufferType::SliceParameter(SliceParameter::H264(ref mut params)) => {
                 params.inner_mut().len()
             }
+            #[cfg(libva_1_14_or_higher)]
             BufferType::SliceParameter(SliceParameter::AV1(ref mut params)) => {
                 params.inner_mut().len()
             }
@@ -88,6 +91,7 @@ impl Buffer {
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
                 ),
+                #[cfg(libva_1_14_or_higher)]
                 PictureParameter::AV1(ref mut wrapper) => (
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
@@ -127,6 +131,7 @@ impl Buffer {
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
                 ),
+                #[cfg(libva_1_14_or_higher)]
                 SliceParameter::AV1(ref mut wrapper) => (
                     wrapper.inner_mut().as_mut_ptr() as *mut std::ffi::c_void,
                     std::mem::size_of::<bindings::VASliceParameterBufferAV1>(),
@@ -197,6 +202,7 @@ impl Buffer {
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
                 ),
+                #[cfg(libva_1_14_or_higher)]
                 EncSequenceParameter::AV1(ref mut wrapper) => (
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
@@ -220,6 +226,7 @@ impl Buffer {
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
                 ),
+                #[cfg(libva_1_14_or_higher)]
                 EncPictureParameter::AV1(ref mut wrapper) => (
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
@@ -235,6 +242,7 @@ impl Buffer {
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
                 ),
+                #[cfg(libva_1_14_or_higher)]
                 EncSliceParameter::AV1(ref mut wrapper) => (
                     wrapper.inner_mut() as *mut _ as *mut std::ffi::c_void,
                     std::mem::size_of_val(wrapper.inner_mut()),
@@ -425,6 +433,7 @@ pub enum PictureParameter {
     HEVCRext(hevc::PictureParameterBufferHEVCRext),
     /// Wrapper over VAPictureParameterBufferHEVCScc
     HEVCScc(hevc::PictureParameterBufferHEVCScc),
+    #[cfg(libva_1_14_or_higher)]
     /// Wrapper over VADecPictureParameterBufferAV1
     AV1(av1::PictureParameterBufferAV1),
     /// Wrapper over VAPictureParameterBufferJPEGBaseline
@@ -447,6 +456,7 @@ pub enum SliceParameter {
     HEVC(hevc::SliceParameterBufferHEVC),
     /// Wrapper over VASliceParameterBufferHEVCRext
     HEVCRext(hevc::SliceParameterBufferHEVCRext),
+    #[cfg(libva_1_14_or_higher)]
     /// Wrapper over VASliceParameterBufferAV1
     AV1(av1::SliceParameterBufferAV1),
     /// Wrapper over VASliceParameterBufferJPEGBaseline
@@ -491,6 +501,7 @@ pub enum EncSequenceParameter {
     VP8(vp8::EncSequenceParameterBufferVP8),
     /// Abstraction over `VAEncSequenceParameterBufferVP9`
     VP9(vp9::EncSequenceParameterBufferVP9),
+    #[cfg(libva_1_14_or_higher)]
     /// Abstraction over `VAEncSequenceParameterBufferAV1`
     AV1(av1::EncSequenceParameterBufferAV1),
 }
@@ -505,6 +516,7 @@ pub enum EncPictureParameter {
     VP8(vp8::EncPictureParameterBufferVP8),
     /// Abstraction over `VAEncPictureParameterBufferVP9`
     VP9(vp9::EncPictureParameterBufferVP9),
+    #[cfg(libva_1_14_or_higher)]
     /// Abstraction over `VAEncPictureParameterBufferAV1`
     AV1(av1::EncPictureParameterBufferAV1),
 }
@@ -515,6 +527,7 @@ pub enum EncSliceParameter {
     H264(h264::EncSliceParameterBufferH264),
     /// Abstraction over `VAEncSliceParameterBufferHEVC`
     HEVC(hevc::EncSliceParameterBufferHEVC),
+    #[cfg(libva_1_14_or_higher)]
     /// Abstraction over `VAEncTileGroupBufferAV1`
     AV1(av1::EncTileGroupBufferAV1),
 }

--- a/lib/src/buffer/enc_misc.rs
+++ b/lib/src/buffer/enc_misc.rs
@@ -138,6 +138,7 @@ impl EncMiscParameterRateControl {
                 ICQ_quality_factor: icq_quality_factor,
                 max_qp,
                 quality_factor,
+                #[cfg(libva_1_10_or_higher)]
                 target_frame_size,
                 ..Default::default()
             },

--- a/lib/src/buffer/hevc.rs
+++ b/lib/src/buffer/hevc.rs
@@ -1142,7 +1142,9 @@ impl EncSliceParameterBufferHEVC {
             slice_beta_offset_div2,
             slice_tc_offset_div2,
             slice_fields,
+            #[cfg(libva_1_10_or_higher)]
             pred_weight_table_bit_offset,
+            #[cfg(libva_1_10_or_higher)]
             pred_weight_table_bit_length,
             va_reserved: Default::default(),
         }))

--- a/lib/src/buffer/jpeg_baseline.rs
+++ b/lib/src/buffer/jpeg_baseline.rs
@@ -57,6 +57,7 @@ impl PictureParameterBufferJPEGBaseline {
             num_components,
             color_space,
             rotation,
+            #[cfg(libva_1_20_or_higher)]
             crop_rectangle,
             va_reserved: Default::default(),
         }))


### PR DESCRIPTION
Fixes build with VAAPI 1.9.0 and warnings due to undeclared cfg's like the one below:

```
warning: unexpected `cfg` condition name: `libva_1_20_or_higher`
   --> lib/src/surface.rs:311:23
    |
311 |                 #[cfg(libva_1_20_or_higher)]
```