### PR TITLE
Fix lifetime warnings in Image

### DIFF
--- a/lib/src/image.rs
+++ b/lib/src/image.rs
@@ -122,7 +122,7 @@ impl<'a> Image<'a> {
         mut format: bindings::VAImageFormat,
         coded_resolution: (u32, u32),
         visible_rect: (u32, u32),
-    ) -> Result<Image, VaError> {
+    ) -> Result<Image<'a>, VaError> {
         // An all-zero byte-pattern is a valid initial value for `VAImage`.
         let mut image: bindings::VAImage = Default::default();
         let dpy = surface.display().handle();

--- a/lib/src/picture.rs
+++ b/lib/src/picture.rs
@@ -277,7 +277,7 @@ impl<S: PictureReclaimableSurface, T> Picture<S, T> {
     pub fn derive_image<'a, D: SurfaceMemoryDescriptor + 'a>(
         &'a self,
         visible_rect: (u32, u32),
-    ) -> Result<Image, VaError>
+    ) -> Result<Image<'a>, VaError>
     where
         T: Borrow<Surface<D>>,
     {
@@ -292,7 +292,7 @@ impl<S: PictureReclaimableSurface, T> Picture<S, T> {
         format: bindings::VAImageFormat,
         coded_resolution: (u32, u32),
         visible_rect: (u32, u32),
-    ) -> Result<Image, VaError>
+    ) -> Result<Image<'a>, VaError>
     where
         T: Borrow<Surface<D>>,
     {


### PR DESCRIPTION
```
warning: elided lifetime has a name
   --> lib/src/image.rs:125:17
    |
42  | impl<'a> Image<'a> {
    |      -- lifetime `'a` declared here
...
125 |     ) -> Result<Image, VaError> {
    |                 ^^^^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default

warning: elided lifetime has a name
   --> lib/src/picture.rs:280:17
    |
277 |     pub fn derive_image<'a, D: SurfaceMemoryDescriptor + 'a>(
    |                         -- lifetime `'a` declared here
...
280 |     ) -> Result<Image, VaError>
    |                 ^^^^^ this elided lifetime gets resolved as `'a`

warning: elided lifetime has a name
   --> lib/src/picture.rs:295:17
    |
290 |     pub fn create_image<'a, D: SurfaceMemoryDescriptor + 'a>(
    |                         -- lifetime `'a` declared here
...
295 |     ) -> Result<Image, VaError>
    |                 ^^^^^ this elided lifetime gets resolved as `'a`
```