### PR TITLE
Expose handle and id methods

### DIFF
--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -74,7 +74,7 @@ impl Context {
     }
 
     /// Returns the ID of this context.
-    pub(crate) fn id(&self) -> bindings::VAContextID {
+    pub fn id(&self) -> bindings::VAContextID {
         self.id
     }
 

--- a/lib/src/display.rs
+++ b/lib/src/display.rs
@@ -138,7 +138,7 @@ impl Display {
     }
 
     /// Returns the handle of this display.
-    pub(crate) fn handle(&self) -> bindings::VADisplay {
+    pub fn handle(&self) -> bindings::VADisplay {
         self.handle
     }
 


### PR DESCRIPTION
The encoder calls the FFI `va*` directly in two cases that `cros-libva` does not wrap: packed SPS/PPS/SEI headers (`vaCreateBuffer` with `VAEncPackedHeader{Parameter,Data}BufferType`) and the import of DMA-BUF with zero-copy from VPP. Both require the raw VADisplay and VAContextID handlers to make the FFI calls; the main project keeps those accessors private, so I am creating this PR to make them public.